### PR TITLE
Handle case where `mac_list` is `{}` in Switch Status API response

### DIFF
--- a/fbx/http_client.go
+++ b/fbx/http_client.go
@@ -49,7 +49,6 @@ func NewFreeboxHttpClient() *FreeboxHttpClient {
 
 func (f *FreeboxHttpClient) Get(url string, out interface{}, callbacks ...FreeboxHttpClientCallback) error {
 	req, err := http.NewRequestWithContext(f.ctx, "GET", url, nil)
-
 	if err != nil {
 		return err
 	}
@@ -114,6 +113,12 @@ func (f *FreeboxHttpClient) do(req *http.Request, out interface{}) error {
 	}{
 		Result: out,
 	}
+
+	// Workaround for Switch Status API: mac_list is supposed to be an array. However, it is sometimes
+	// missing (which is fine), or an empty object `{}`, which causes json.Unmarshal to fail as it is
+	// expeting an array. This seems to be happening with sfp_lan.
+	body = bytes.Replace(body, []byte(`"mac_list":{}`), []byte(`"mac_list":[]`), 1)
+
 	if err := json.Unmarshal(body, &result); err != nil {
 		return err
 	}


### PR DESCRIPTION
Fix for https://github.com/trazfr/freebox-exporter/issues/3:

```
collector.go:346: json: cannot unmarshal object into Go struct field MetricsFreeboxSwitchStatus.result.mac_list of type []*struct { Mac string "json:\"mac\""; Hostname string "json:\"hostname\"" }
```


Full response for reference:

```json
{
    "success": true,
    "result": [
        {
            "duplex": "full",
            "mac_list": [
                {
                    "mac": "xx:xx:xx:xx:xx:xx",
                    "hostname": "some device :)"
                }
            ],
            "name": "Ethernet 1",
            "link": "up",
            "id": 1,
            "mode": "100BaseTX-FD",
            "speed": "100",
            "rrd_id": "1"
        },
        {
            "duplex": "full",
            "mac_list": [
                {
                    "mac": "xx:xx:xx:xx:xx:xx",
                    "hostname": "some device :)"
                }
            ],
            "name": "Ethernet 2",
            "link": "up",
            "id": 2,
            "mode": "100BaseTX-FD",
            "speed": "100",
            "rrd_id": "2"
        },
        {
            "duplex": "full",
            "mac_list": [
                {
                    "mac": "xx:xx:xx:xx:xx:xx",
                    "hostname": "some device :)"
                },
                {
                    "mac": "xx:xx:xx:xx:xx:xx",
                    "hostname": "some device :)"
                },
                {
                    "mac": "xx:xx:xx:xx:xx:xx",
                    "hostname": "some device :)"
                },
                {
                    "mac": "xx:xx:xx:xx:xx:xx",
                    "hostname": "some device :)"
                },
                {
                    "mac": "xx:xx:xx:xx:xx:xx",
                    "hostname": "some device :)"
                }
            ],
            "name": "Ethernet 3",
            "link": "up",
            "id": 3,
            "mode": "1000BaseT-FD",
            "speed": "1000",
            "rrd_id": "3"
        },
        {
            "duplex": "full",
            "mac_list": [
                {
                    "mac": "xx:xx:xx:xx:xx:xx",
                    "hostname": "some device :)"
                }
            ],
            "name": "Ethernet 4",
            "link": "up",
            "id": 4,
            "mode": "100BaseTX-FD",
            "speed": "100",
            "rrd_id": "4"
        },
        {
            "duplex": "half",
            "name": "Freeplug",
            "link": "down",
            "id": 5,
            "mode": "10BaseT-HD",
            "speed": "10",
            "rrd_id": "freeplug"
        },
        {
            "duplex": "auto",
            "mac_list": {}, // ISSUE HERE
            "name": "Sfp lan",
            "link": "down",
            "id": 9999,
            "mode": "1000BaseT-FD",
            "speed": "1000",
            "rrd_id": "sfp_lan"
        }
    ]
}
```